### PR TITLE
1.8.7 compatibility

### DIFF
--- a/lib/methodfinder.rb
+++ b/lib/methodfinder.rb
@@ -43,7 +43,7 @@ class Object
 
         klass.ancestors.each { |ancestor| ret -= blacklist[ancestor.to_s.intern] }
 
-        ret.sort
+        ret.map(&:to_s).sort.map(&:intern)
       end
 
       def find_classes_and_modules


### PR DESCRIPTION
Hi,

Could you please pull this 1-line change? It fixes methodfinder in Ruby 1.8.7. Thanks.

Ruby 1.8.7 doesn't have Symbol#<=>.
Convert symbols to strings before sorting.
(Works in 1.9.2 too).
