### PR TITLE
Make methodfinder play nice with Pry

### DIFF
--- a/lib/methodfinder.rb
+++ b/lib/methodfinder.rb
@@ -26,6 +26,11 @@ class MethodFinder
   INSTANCE_METHOD_BLACKLIST[:Object] << :find_method # prevent stack overflow
   INSTANCE_METHOD_BLACKLIST[:Object] << :gem # funny testing stuff w/ Bundler
 
+  if defined? Pry
+    INSTANCE_METHOD_BLACKLIST[:Object] << :pry
+    CLASS_METHOD_BLACKLIST[:Object] << :pry
+  end
+
   class << self
     def find(obj, res, *args, &block)
       redirect_streams


### PR DESCRIPTION
[Pry](http://pry.github.com) is an IRB alternative that is way cooler.

Also, it is very useful if you are teaching students. Like methodfinder. It will be nice if they play together.

Pry defines `#pry` method on `Object`, that spawns a sub-shell with the object as the current binding. Much like `#irb` in IRB. Problem is, when you try to find a method on anything, it invokes `#pry` and you get a new shell with the object as context. Very confusing for beginners.

This solves it by blacklisting `#pry` if `Pry` is defined (which implies a running pry session).
