### PR TITLE
Compatibility updates, fixes and workarounds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,14 @@
+sudo: false
+language: ruby
+dist: trusty
 rvm:
-  - 1.9.3
-  - 2.0.0
-  - jruby
-  - rbx-19mode
+  - 2.1.10
+  - 2.2.6
+  - 2.3.3
+  - 2.4.0
+  - jruby-1.7.26
+  - rbx
+  - ruby-head
+matrix:
+  allow_failures:
+      - rvm: rbx

--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,13 @@
 source 'https://rubygems.org'
 
-gem 'rake'
-gem 'minitest',  group: :test
-gem 'rdoc', platform: :rbx
+group :test do
+  gem 'minitest'
+end
+
+group :test, :development do
+  gem 'rake'
+end
+
+group :development do
+  gem 'rdoc', platform: :rbx
+end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,9 +1,9 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    minitest (2.6.0)
-    rake (0.9.2)
-    rdoc (4.0.0)
+    minitest (5.10.1)
+    rake (12.0.0)
+    rdoc (5.0.0)
 
 PLATFORMS
   java
@@ -13,3 +13,6 @@ DEPENDENCIES
   minitest
   rake
   rdoc
+
+BUNDLED WITH
+   1.14.3

--- a/test/test_methodfinder.rb
+++ b/test/test_methodfinder.rb
@@ -1,7 +1,7 @@
 require 'minitest/autorun'
 require 'methodfinder'
 
-class TestMethodFinder < MiniTest::Unit::TestCase
+class TestMethodFinder < Minitest::Test
   def test_finding_method_with_no_argument_or_block
     result = MethodFinder.find('a', 'A')
     assert result.include?("String#capitalize")
@@ -9,9 +9,9 @@ class TestMethodFinder < MiniTest::Unit::TestCase
   end
 
   def test_finding_method_with_an_argument_and_no_block
-    result = MethodFinder.find(10, 1, 3)
-    assert result.include?("Fixnum#%")
-    assert result.include?("Fixnum#modulo")
+    result = MethodFinder.find('twothreefour', 'three', 3, 5)
+    assert result.include?("String#slice")
+    assert result.include?("String#slice!")
   end
 
   def test_finding_method_with_a_block


### PR DESCRIPTION
Rubinius:

* use Trusty for Rubinius as per:
  * https://docs.travis-ci.com/user/languages/ruby/
  * https://github.com/rubinius/rubinius/issues/3717#issuecomment-267106474

* remove obsolete Rubinius version (rbx-19mode) as per:
  * https://docs.travis-ci.com/user/languages/ruby/

* use the recommended Rubinius version (rbx):
  * https://github.com/travis-ci/docs-travis-ci-com/pull/740

* allow Rubinius tests to fail due to Travis/RVM issues and incompatibility with Rake:
  * https://github.com/vmg/redcarpet/issues/580
  * https://github.com/ruby/rake/pull/150

MRI:

 * remove end-of-life Ruby versions (1.9, 2.0)
* update test to remove reference to obsolete constant (Fixnum) in Ruby 2.4

Misc:

* update dev dependencies
* move rake from default to test/development groups

See Also:

* https://github.com/arunagw/omniauth-twitter/pull/114