### PR TITLE
Allow tested method names to be dumped to STDERR via an environment variable

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -68,6 +68,18 @@ If the second parameter is omitted, all methods of the class or module will be r
     MethodFinder.find_in_class_or_module(Math)
     #=> [:acos, :acosh, :asin ... :tanh]
 
+== Troubleshooting
+
+If the +$METHOD_FINDER_DEBUG+ environment variable is set, the name of each candidate method is printed to stderr before it is invoked. This can be useful to identify (and blacklist) misbehaving methods.
+
+It can be set on the command line e.g.:
+
+    $ METHOD_FINDER_DEBUG=1 irb
+
+Or inside IRB/Pry:
+
+    >> ENV['METHOD_FINDER_DEBUG'] = '1'
+
 == Warning
 
 Common sense not included!

--- a/lib/methodfinder.rb
+++ b/lib/methodfinder.rb
@@ -22,7 +22,9 @@ class Object
 
   def find_method(*args, &block)
     if block
+      debug = ENV['METHOD_FINDER_DEBUG']
       mets = MethodFinder.methods_to_try(self).select do |met|
+        STDERR.puts met if debug
         self.class.class_eval("alias :unknown #{met}")
         obj = self.dup rescue self # dup doesn't work for immutable types
         block.call(obj) rescue nil
@@ -70,10 +72,12 @@ module MethodFinder
     def find(obj, res, *args, &block)
       redirect_streams
 
+      debug = ENV['METHOD_FINDER_DEBUG']
       mets = methods_to_try(obj).select do |met|
         o = obj.dup rescue obj
         m = o.method(met)
         if m.arity <= args.size
+          STDERR.puts met if debug
           a = args.empty? && ARGS.has_key?(met) ? ARGS[met] : args
           m.call(*a, &block) == res rescue nil
         end


### PR DESCRIPTION
Setting `$METHOD_FINDER_DEBUG` dumps the name of each tested method before it is invoked. This is useful for diagnosing (and then blacklisting) misbehaving methods, including:

* methods which alter streams
* methods which hang
* methods which mutate the receiver